### PR TITLE
correct an ImportError of jasonpickle.compat.unicode

### DIFF
--- a/wise/jsonpickle_numpy.py
+++ b/wise/jsonpickle_numpy.py
@@ -16,7 +16,7 @@ import jsonpickle
 try:
     from jsonpickle.compat import unicode
 except ImportError:
-    from jsonpickle.compat import unicode_literals as unicode
+    from jsonpickle.compat import ustr as unicode
 
 __all__ = ['register_handlers', 'unregister_handlers']
 

--- a/wise/jsonpickle_numpy.py
+++ b/wise/jsonpickle_numpy.py
@@ -12,7 +12,11 @@ import numpy as np
 
 import ast
 import jsonpickle
-from jsonpickle.compat import unicode
+# import unicode from jsonpickle, depending on its version apparently function name is different.
+try:
+    from jsonpickle.compat import unicode
+except ImportError:
+    from jsonpickle.compat import unicode_literals as unicode
 
 __all__ = ['register_handlers', 'unregister_handlers']
 


### PR DESCRIPTION
Hi @flomertens ,

I have realized that, for some jsonpickle's versions, jsonpickle.compat.unicode does not exist and therefore cannot be imported. Everything seems to work fine if we load jsonpickle.compat.unicode_literals instead in such a case. 

This commit adds try & except sentences to adopt this fix if one encounters ImportError.